### PR TITLE
Fix typo in `block_categories` filter

### DIFF
--- a/Services/GutenbergBlockService.php
+++ b/Services/GutenbergBlockService.php
@@ -7,7 +7,7 @@ class GutenbergBlockService {
 
     public function register_hooks() {
         add_action('enqueue_block_editor_assets', [$this, 'enqueue_block_editor_assets']);
-        add_filter('block-categories', [$this, 'register_block_category'], 10, 2);
+        add_filter('block_categories', [$this, 'register_block_category'], 10, 2);
     }
 
     protected function vendor_dir() {


### PR DESCRIPTION
In order to register the block category correctly, this commit fixes a
typo in our block category registration filter.